### PR TITLE
Forum Quickfixes

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -12,6 +12,7 @@
 #  created_at     :datetime
 #  updated_at     :datetime
 #  capsule_id     :integer
+#  last_post_id   :integer
 #
 
 class Topic < ActiveRecord::Base
@@ -37,8 +38,13 @@ class Topic < ActiveRecord::Base
     reply.course_id = self.course_id
     self.last_poster_id = reply.author_id
     self.replies << reply
+    self.last_post_id = reply.id
     update_attribute(:updated_at, Time.now)
     self.save
+  end
+
+  def last_post_page
+    (self.replies.count / 10).floor + 1
   end
 
 end

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -35,37 +35,41 @@
 
 <% end %>
 
+<div class="row">
+  <div class="small-6 columns">
+    <table class="listing full">
+      <thead>
+        <th>Capsules</th>
+      </thead>
+      <tbody>
+        <%= render @capsules %>
+        <% if @capsules.empty? %>
+          <tr>
+            <td>
+              <span>No capsules found.</span>
+            </td>
+          </tr> 
+        <% end %>
+      </tbody>
+    </table>
 
-<table class="listing">
-  <thead>
-    <th>Capsules</th>
-  </thead>
-	<tbody>
-		<%= render @capsules %>
-    <% if @capsules.empty? %>
-      <tr>
-        <td>
-          <span>No capsules found.</span>
-        </td>
-      </tr> 
-    <% end %>
-	</tbody>
-</table>
-
-<%= render "documents/documents", container: @course %>
-
-<table class="listing">
-  <thead>
-    <th>Recent Discussion (<%= link_to "view all", course_topics_path(@course) %>)</th>
-  </thead>
-  <tbody>
-    <%= render @topics %>
-    <% if @topics.empty? %>
-      <tr>
-        <td>
-          <span>No topics found.</span>
-        </td>
-      </tr> 
-    <% end %>
-  </tbody>
-</table>
+    <%= render "documents/documents", container: @course, table_class: "listing full" %>
+  </div>
+  <div class="small-6 columns">
+    <table class="listing full">
+      <thead>
+        <th>Recent Discussion (<%= link_to "view all", course_topics_path(@course) %>)</th>
+      </thead>
+      <tbody>
+        <%= render @topics, link_to_post: true %>
+        <% if @topics.empty? %>
+          <tr>
+            <td>
+              <span>No topics found.</span>
+            </td>
+          </tr> 
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/documents/_documents.html.erb
+++ b/app/views/documents/_documents.html.erb
@@ -1,4 +1,9 @@
-<table class="listing">
+<%
+  # Optional local variables that can be passed in
+  table_class ||= "listing"
+%>
+
+<table class="<%= table_class %>">
   <thead>
     <th>File</th>
     <th>Description</th>

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,6 +1,15 @@
+<%
+  # Optional local variables that can be passed in
+  link_to_post ||= false
+%>
+
 <tr>
   <td>
-    <%= link_to topic.name, [@course, topic] %>
+    <% if link_to_post && topic.last_post_id %>
+      <%= link_to topic.name, course_topic_path(@course, topic) + "?page=#{topic.last_post_page}#reply-#{topic.last_post_id}" %>
+    <% else %>
+      <%= link_to topic.name, [@course, topic] %>
+    <% end %>
   </td>
   <% if defined? full %>
     <td><%= topic.replies.count %></td>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -22,8 +22,8 @@
     <tbody>
       <% if @topics.empty? %>
         <tr>
-          <td>
-            <span>No capsules found.</span>
+          <td colspan="4">
+            <span>No topics found.</span>
           </td>
         </tr> 
       <% end %>

--- a/db/migrate/20140212005006_add_last_post_id_to_topics.rb
+++ b/db/migrate/20140212005006_add_last_post_id_to_topics.rb
@@ -1,0 +1,5 @@
+class AddLastPostIdToTopics < ActiveRecord::Migration
+  def change
+    add_column :topics, :last_post_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140129235603) do
+ActiveRecord::Schema.define(version: 20140212005006) do
 
   create_table "capsules", force: true do |t|
     t.string   "name"
@@ -29,14 +29,9 @@ ActiveRecord::Schema.define(version: 20140129235603) do
 
   create_table "courses", force: true do |t|
     t.string   "name"
+    t.integer  "instructor_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "instructor_id"
-  end
-
-  create_table "courses_users", force: true do |t|
-    t.integer "course_id"
-    t.integer "user_id"
   end
 
   create_table "documents", force: true do |t|
@@ -84,6 +79,7 @@ ActiveRecord::Schema.define(version: 20140129235603) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "capsule_id"
+    t.integer  "last_post_id"
   end
 
   create_table "users", force: true do |t|
@@ -103,8 +99,8 @@ ActiveRecord::Schema.define(version: 20140129235603) do
     t.string   "name"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
   create_table "video_texts", force: true do |t|
     t.text     "content"


### PR DESCRIPTION
Just a few changes to fix issue #32.

If I understand you correctly, the first part of the issue is that the links were pointing to the top of the topic rather than the latest post. This has been changed.

The second part of the issue is to move the discussion to the right side of the course page. This brings up a problem that I have outlined in issue #36

(fixes #32)
